### PR TITLE
Check images existence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,5 @@ node_modules
 
 # App config
 .env
-.articles-space-hash
+.sepcontent-space-hash
 /data

--- a/.sepcontent-space-hash
+++ b/.sepcontent-space-hash
@@ -1,1 +1,0 @@
-f9644de3fef6410adbb033b218cf23d05cea055a

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby "2.3.3"
+ruby "2.4.0"
 #ruby-gemset=contentplatform_gems
 
 # If you do not have OpenSSL installed, change

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,7 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.4.0p0
 
 BUNDLED WITH
-   1.14.4
+   1.14.6

--- a/source/articles/_articles.html.slim
+++ b/source/articles/_articles.html.slim
@@ -17,7 +17,8 @@
             | by Alexo Rodriguez
           h2= link_to article.title, article_path(article)
           = link_to article_path(article), class: "articles-item__image" do
-            = image_tag article.image.url, title: article.image.title.present? ? article.image.title : article.title
+            - if article.image
+              = image_tag article.image.url, title: article.image.title.present? ? article.image.title : article.title
           .articles-item__body= truncate(article.body, length: 250)
 
   .pager

--- a/source/articles/show.html.slim
+++ b/source/articles/show.html.slim
@@ -10,7 +10,9 @@
         = image_tag "/assets/components/alexo.png"
         | by Alexo Rodriguez
 
-    .article__image= image_tag article.image.url
+    .article__image
+      - if article.image
+        = image_tag article.image.url
 
     hr
 
@@ -23,7 +25,7 @@
       h2 Related articles
 
       - related.each_with_index do |article, index|
-        = link_to article_path(article), class: "article__related-item article__related-item--#{index == 1 ? :central : :border}", style: "background-image:url(#{article.image.url});"  do
+        = link_to article_path(article), class: "article__related-item article__related-item--#{index == 1 ? :central : :border}", style: "background-image:url(#{article.image.url if article.image});"  do
           .article__related-item__text
             .article__related-item__title= article.title
 

--- a/source/feed.xml.builder
+++ b/source/feed.xml.builder
@@ -17,9 +17,11 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
       xml.published article.date.to_time.iso8601
       xml.updated article.date.to_time.iso8601
       #xml.author { xml.name "Article Author" }
-      xml.link rel: 'enclosure',
-               type: 'image/jpeg',
-               href: article.image.url.gsub(%r{^//}, 'https://')
+      if article.image
+        xml.link rel:  'enclosure',
+                 type: 'image/jpeg',
+                 href: article.image.url.gsub(%r{^//}, 'https://')
+      end
       xml.summary truncate(article.body, length: 250), "type" => "html"
       xml.content Markdown.new(article.body).to_html, "type" => "html"
     end


### PR DESCRIPTION
It turns out that headline images are not assigned to some articles on the old content platform. I believe it is fair only for test database and all production articles have images, but have to add a check on image existence to ensure that all articles will compile.