### PR TITLE
Adjust inner articles images dimensions according to parent block width

### DIFF
--- a/source/stylesheets/components/article.scss
+++ b/source/stylesheets/components/article.scss
@@ -35,6 +35,10 @@
     font-size: 19px;
     line-height: 1.9;
     padding-bottom: 2rem;
+    img {
+      display: inline-block;
+      width: 100%;
+    }
   }
   hr, .social {
     margin: 4rem 0;


### PR DESCRIPTION
This PR fixes large images inside articles so they won't overflow the screen (from feedback for issue [#2266](https://github.com/saberespoder/inboundsms/issues/2266))

![image](https://cloud.githubusercontent.com/assets/160712/25126111/52090ef6-245b-11e7-8862-fee267838e47.png)
