### PR TITLE
Remove `.html` extension out of feed urls

### DIFF
--- a/source/feed.xml.builder
+++ b/source/feed.xml.builder
@@ -13,8 +13,8 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
   content[0..config[:feed_articles]].each do |article|
     xml.entry do
       xml.title article.title
-      xml.link rel: :alternate, href: "#{site_url}#{article_path(article)}"
-      xml.id "#{site_url}#{article_path(article)}"
+      xml.link rel: :alternate, href: "#{site_url}#{article_path(article).gsub(".html", "")}"
+      xml.id "#{site_url}#{article_path(article).gsub(".html", "")}"
       xml.published article.date.to_time.iso8601
       xml.updated article.date.to_time.iso8601
       #xml.author { xml.name "Article Author" }


### PR DESCRIPTION
It turns out that `link_to` helper mutates pages URLs in a way defined in the config, but this approach doesn't work for the feed builder. That's why page URLs inside the feed were actually invalid and this PR supposed to resolve it.

Also indirectly related to [issue #2300](https://github.com/saberespoder/inboundsms/issues/2300)