### PR TITLE
Add categories links inside articles

### DIFF
--- a/lib/blog_helpers.rb
+++ b/lib/blog_helpers.rb
@@ -18,6 +18,10 @@ module BlogHelpers
     "/#{entry_point}/#{category.title.downcase}/#{article.slug}.html"
   end
 
+  def category_links(categories)
+    categories.map { |category| link_to(category.title, "/#{category.title.downcase}").html_safe }.join(", ")
+  end
+
   def previous_page(slicer)
     page = current_page_index(slicer)
     last = slicer[:collection].index(slicer[:collection].last)

--- a/source/articles/show.html.slim
+++ b/source/articles/show.html.slim
@@ -12,7 +12,7 @@
       h1= title
       .article__author
         = image_tag "/assets/components/alexo.png"
-        | by Alexo Rodriguez
+        | by Alexo Rodriguez in #{category_links(article.categories)}
 
     .article__image
       - if article.image
@@ -21,6 +21,8 @@
     .social
       .sharethis-inline-share-buttons
 
+    hr 
+    
     .article__inner
       .article__text= Markdown.new(article.body).to_html
 


### PR DESCRIPTION
No issue assigned, but @FanaHOVA once mentioned that it would be nice to have links to parent categories inside articles so here we go