### PR TITLE
Add call-to-action buttons to the articles page

### DIFF
--- a/source/_widget.html.slim
+++ b/source/_widget.html.slim
@@ -1,0 +1,2 @@
+#sep-widget
+= javascript_include_tag config[:widget_url]

--- a/source/articles/_button.html.slim
+++ b/source/articles/_button.html.slim
@@ -1,0 +1,1 @@
+= link_to button.text, button.href, target: :blank, class: 'buttons__item'

--- a/source/articles/_buttons.html.slim
+++ b/source/articles/_buttons.html.slim
@@ -1,0 +1,5 @@
+- buttons = article.buttons.select { |b| b.position == position.to_s }
+- buttons.any?
+  .buttons class="buttons--#{position}"
+    - buttons.each do |button|
+      = partial 'button', locals: { button: button }

--- a/source/articles/_buttons.html.slim
+++ b/source/articles/_buttons.html.slim
@@ -1,5 +1,6 @@
-- buttons = article.buttons.select { |b| b.position == position.to_s }
-- buttons.any?
-  .buttons class="buttons--#{position}"
-    - buttons.each do |button|
-      = partial 'button', locals: { button: button }
+- if article.buttons
+  - buttons = article.buttons.select { |b| b.position == position.to_s }
+  - buttons.any?
+    .buttons class="buttons--#{position}"
+      - buttons.each do |button|
+        = partial 'button', locals: { button: button }

--- a/source/articles/show.html.slim
+++ b/source/articles/show.html.slim
@@ -14,7 +14,11 @@
 
     .article__image
       - if article.image
-        = image_tag article.image.url
+        - if article.image_href
+          = link_to article.image_href, target: :blank, title: article.title do
+            = image_tag article.image.url
+        - else
+          = image_tag article.image.url
 
     .social
       .sharethis-inline-share-buttons

--- a/source/articles/show.html.slim
+++ b/source/articles/show.html.slim
@@ -22,7 +22,9 @@
     hr
 
     .article__inner
+      = partial 'buttons', locals: { position: :top }
       .article__text= Markdown.new(article.body).to_html
+      = partial 'buttons', locals: { position: :bottom }
 
     - unless article.display_widget == false
       .article__questions

--- a/source/articles/show.html.slim
+++ b/source/articles/show.html.slim
@@ -31,8 +31,6 @@
       = partial 'buttons', locals: { position: :bottom }
 
     - unless article.display_widget == false
-      .article__questions
-        #sep-widget
-        = javascript_include_tag config[:widget_url]
+      .article__questions= partial 'widget'
 
 = partial 'related', locals: { related: related }

--- a/source/questions/show.html.slim
+++ b/source/questions/show.html.slim
@@ -10,9 +10,7 @@
   hr
 
   .question
-    .question__form
-      #sep-widget
-      = javascript_include_tag config[:widget_url]
+    .question__form= partial 'widget'
 
     - if answers && answers.size > 0
       .question__answers

--- a/source/stylesheets/components/buttons.scss
+++ b/source/stylesheets/components/buttons.scss
@@ -9,7 +9,7 @@
     margin-right: 0.6rem;
     font-size: 1.5rem;
     color: #008951;
-    border: #00a15f 3px solid;
+    border: #00a15f 2px solid;
     border-radius: 50px;
     &:hover {
       color: #FFF;

--- a/source/stylesheets/components/buttons.scss
+++ b/source/stylesheets/components/buttons.scss
@@ -1,0 +1,20 @@
+.buttons {
+  text-align: center;
+  margin-bottom: 2rem;
+  height: 5rem;
+  overflow: hidden;
+  &__item {
+    display: inline-block;
+    padding: 0.6em 1.2em;
+    margin-right: 0.6rem;
+    font-size: 1.5rem;
+    color: #008951;
+    border: #00a15f 3px solid;
+    border-radius: 50px;
+    &:hover {
+      color: #FFF;
+      border-color: #008951;
+      background-color: #00a15f;
+    }
+  }
+}

--- a/source/stylesheets/styles.scss
+++ b/source/stylesheets/styles.scss
@@ -13,4 +13,5 @@
 @import "components/questions";
 @import "components/question";
 @import "components/placeholder";
+@import "components/buttons";
 @import "components/pager";


### PR DESCRIPTION
This PR adds LARGE call to action buttons (top and bottom position) support and makes it possible to set `href` attribute for internal articles images.

![image](https://user-images.githubusercontent.com/160712/30056695-e76dda06-925d-11e7-9c6d-4bf15228e995.png)
