### PR TITLE
Be able to turn related articles off

### DIFF
--- a/data/sample/article/3.yaml
+++ b/data/sample/article/3.yaml
@@ -39,3 +39,4 @@
   :is_active: true
 :is_offer: false
 :display_widget: false
+:display_related: false

--- a/data/sample/article/9.yaml
+++ b/data/sample/article/9.yaml
@@ -80,3 +80,4 @@
   :is_active: false
 :is_offer: false
 :display_widget: true
+:display_related: true

--- a/source/articles/show.html.slim
+++ b/source/articles/show.html.slim
@@ -30,7 +30,8 @@
       .article__text= Markdown.new(article.body).to_html
       = partial 'buttons', locals: { position: :bottom }
 
-    - unless article.display_widget == false
+    - if article.display_widget != false
       .article__questions= partial 'widget'
 
-= partial 'related', locals: { related: related }
+- if article.display_related != false
+  = partial 'related', locals: { related: related }

--- a/spec/features/article_spec.rb
+++ b/spec/features/article_spec.rb
@@ -15,11 +15,6 @@ describe 'article', type: :feature do
       expect(page.find('h1')).to have_content('Campaña de Momentos: Consejo para padres con hijas entre 8 y 10 años')
     end
 
-    it 'has related articles block' do
-      expect(page).to have_selector('.placeholder')
-      expect(page.find('.placeholder')).to have_content('Contenido Relacionado')
-    end
-
     it 'has links to parent categories' do
       categories = page.find('.article__categories')
       expect(categories.find_all('a').length).to eq(2)
@@ -53,6 +48,23 @@ describe 'article', type: :feature do
     it 'displayed if not defined' do
       click_link('Aprenda inglés fácilmente desde su teléfono móvil')
       expect(page).to have_selector('#sep-widget')
+    end
+  end
+
+  context 'related articles state' do
+    it 'does not displayed if defined to false' do
+      click_link('Campaña de Momentos: Consejo para padres con hijas entre 8 y 10 años')
+      expect(page).not_to have_selector('.placeholder')
+    end
+    it 'displayed if defined to true' do
+      click_link('El top 6 del Q&A')
+      expect(page).to have_selector('.placeholder')
+      expect(page.find('.placeholder')).to have_content('Contenido Relacionado')
+    end
+    it 'displayed if not defined' do
+      click_link('Aprenda inglés fácilmente desde su teléfono móvil')
+      expect(page).to have_selector('.placeholder')
+      expect(page.find('.placeholder')).to have_content('Contenido Relacionado')
     end
   end
 end


### PR DESCRIPTION
This PR simply turns off related articles block if so defined on Contentful side (see issue #105)