### PR TITLE
Disabling related articles block

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -8,10 +8,10 @@ set :content_url,        ENV["URL"]
 set :content_title,      'SABEResPODER'
 set :content_subtitle,   'Elija su ruta al conocimiento'
 set :questions_subtitle, 'Bienvenido al portal de conocimiento de SEP. ¿Tiene preguntas? ¡Tenemos respuestas!'
-set :platform_url,       ENV["PLATFORM_URL"]
-set :phone_number,       ENV["PHONE_NUMBER"]
-set :feed_articles,      ENV["ARTICLES_PER_FEED"].to_i
-set :widget_url,         ENV["WIDGET_URL"]
+set :platform_url,       ENV['PLATFORM_URL']
+set :phone_number,       ENV['PHONE_NUMBER']
+set :feed_articles,      ENV['ARTICLES_PER_FEED'].to_i
+set :widget_url,         ENV['WIDGET_URL']
 
 page "/feed.xml", layout: false
 page "404.html",  layout: :errors, directory_index: false
@@ -97,20 +97,22 @@ end
 
 # Questions routes
 
-proxy "/preguntas/index.html", "/questions/index.html",
-  locals: { grouped_questions: question_groups }
+if models.include?('question')
+  proxy "/preguntas/index.html", "/questions/index.html",
+    locals: { grouped_questions: question_groups }
 
-category_entries.each do |category|
-  if question_groups[category.title]
-    proxy "/preguntas/#{category.title.downcase}.html", "/questions/category.html",
-      locals: { category_title: category.title, category_questions: question_groups[category.title] }
+  category_entries.each do |category|
+    if question_groups[category.title]
+      proxy "/preguntas/#{category.title.downcase}.html", "/questions/category.html",
+        locals: { category_title: category.title, category_questions: question_groups[category.title] }
+    end
   end
-end
 
-questions.each do |question|
-  question.categories.each do |category|
-    proxy "/preguntas/#{category.title.downcase}/#{question.permalink}.html", "/questions/show.html",
-      locals: { question: question, answers: question.answers, related: related_articles(question) }
+  questions.each do |question|
+    question.categories.each do |category|
+      proxy "/preguntas/#{category.title.downcase}/#{question.permalink}.html", "/questions/show.html",
+        locals: { question: question, answers: question.answers, related: related_articles(question) }
+    end
   end
 end
 

--- a/data/sample/article/3.yaml
+++ b/data/sample/article/3.yaml
@@ -39,3 +39,4 @@
   :is_active: true
 :is_offer: false
 :display_widget: false
+:display_related: false

--- a/data/sample/article/9.yaml
+++ b/data/sample/article/9.yaml
@@ -80,3 +80,4 @@
   :is_active: false
 :is_offer: false
 :display_widget: true
+:display_related: true

--- a/lib/contenido_helpers.rb
+++ b/lib/contenido_helpers.rb
@@ -2,7 +2,8 @@ require 'hashugar'
 
 module ContenidoHelpers
   def self.included(klass)
-    models       = %w(article category page author question).freeze
+    models = %w(article category page author)
+    models.push 'question' unless ENV['REBUILD_QUESTIONS'] == 'false'
     entry_models = (models - %w(article category))
 
     # Make models available inside config file

--- a/source/articles/show.html.slim
+++ b/source/articles/show.html.slim
@@ -30,7 +30,8 @@
       .article__text= Markdown.new(article.body).to_html
       = partial 'buttons', locals: { position: :bottom }
 
-    - unless article.display_widget == false
+    - if article.display_widget != false
       .article__questions= partial 'widget'
 
-= partial 'related', locals: { related: related }
+- if article.display_related != false
+  = partial 'related', locals: { related: related }

--- a/spec/features/article_spec.rb
+++ b/spec/features/article_spec.rb
@@ -15,11 +15,6 @@ describe 'article', type: :feature do
       expect(page.find('h1')).to have_content('Campaña de Momentos: Consejo para padres con hijas entre 8 y 10 años')
     end
 
-    it 'has related articles block' do
-      expect(page).to have_selector('.placeholder')
-      expect(page.find('.placeholder')).to have_content('Contenido Relacionado')
-    end
-
     it 'has links to parent categories' do
       categories = page.find('.article__categories')
       expect(categories.find_all('a').length).to eq(2)
@@ -53,6 +48,23 @@ describe 'article', type: :feature do
     it 'displayed if not defined' do
       click_link('Aprenda inglés fácilmente desde su teléfono móvil')
       expect(page).to have_selector('#sep-widget')
+    end
+  end
+
+  context 'related articles state' do
+    it 'does not displayed if defined to false' do
+      click_link('Campaña de Momentos: Consejo para padres con hijas entre 8 y 10 años')
+      expect(page).not_to have_selector('.placeholder')
+    end
+    it 'displayed if defined to true' do
+      click_link('El top 6 del Q&A')
+      expect(page).to have_selector('.placeholder')
+      expect(page.find('.placeholder')).to have_content('Contenido Relacionado')
+    end
+    it 'displayed if not defined' do
+      click_link('Aprenda inglés fácilmente desde su teléfono móvil')
+      expect(page).to have_selector('.placeholder')
+      expect(page.find('.placeholder')).to have_content('Contenido Relacionado')
     end
   end
 end


### PR DESCRIPTION
– Don't rebuild preguntas if specified
– Be able to turn related articles off



