### PR TITLE
Add received param to article links

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "domready": "^1.0.8",
+    "query-string": "^5.1.0",
     "viewloader": "^1.1.2"
   }
 }

--- a/source/articles/show.html.slim
+++ b/source/articles/show.html.slim
@@ -4,7 +4,7 @@
   = partial "opengraph", locals: { title: title, description: truncate(strip_tags(article.body), length: 200), url: "#{config[:content_url]}#{article_path(article)}", image: article.image && article.image.url }
 
 .container
-  .article data-view-share-this="//platform-api.sharethis.com/js/sharethis.js#property=#{ENV["SHARETHIS"]}&product=inline-share-buttons"
+  .article data-view-trackable='pid' data-view-share-this="//platform-api.sharethis.com/js/sharethis.js#property=#{ENV["SHARETHIS"]}&product=inline-share-buttons"
 
     .article__headline
       h1= title

--- a/source/javascripts/modules/initializer.js
+++ b/source/javascripts/modules/initializer.js
@@ -1,9 +1,11 @@
 import shareThis           from "./share_this"
 import platformPlaceholder from "./platform_placeholder"
+import Trackable           from "./trackable"
 
 let initializer = {}
 
 initializer.shareThis = (el, props) => shareThis(props)
 initializer.platformPlaceholder = (el, props) => new platformPlaceholder(el, props)
+initializer.Trackable = (el, props) => new Trackable(el, props)
 
 export default initializer

--- a/source/javascripts/modules/trackable.js
+++ b/source/javascripts/modules/trackable.js
@@ -1,0 +1,21 @@
+import queryString from "query-string"
+
+class Trackable {
+  constructor(el, param) {
+    let query = queryString.parse(location.search)
+    let links = el.getElementsByTagName('a')
+
+    if (query[param]) {
+      for(var i=0; i < links.length; i++) {
+        // Convert link href to object
+        let href_object = queryString.parseUrl(links[i].href)
+        // Add get param to object
+        href_object['query'][param] = query[param]
+        // Regenerate link href, include received param
+        links[i].href = href_object['url'] + '?' + queryString.stringify(href_object['query'])
+      }
+    }
+  }
+}
+
+export default Trackable

--- a/yarn.lock
+++ b/yarn.lock
@@ -1070,6 +1070,10 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+
 deep-extend@~0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.1.tgz#efe4113d08085f4e6f9687759810f807469e2253"
@@ -2519,6 +2523,14 @@ query-string@^4.1.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.2.tgz#ec0fd765f58a50031a3968c2431386f8947a5cdd"
   dependencies:
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
+
+query-string@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.0.tgz#9583b15fd1307f899e973ed418886426a9976469"
+  dependencies:
+    decode-uri-component "^0.2.0"
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 


### PR DESCRIPTION
This PR includes code which adds `pid` parameter and its value to all article links if it was sent (see issue [#3320](https://github.com/saberespoder/inboundsms/issues/3320))